### PR TITLE
Revert "Removing labeled clusterRole and clusterRoleBindings (#9)"

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,6 @@ def clean():
 
     v1api = client.CoreV1Api()
     v1beta1api = client.AppsV1beta1Api()
-    rbacApi = client.RbacAuthorizationV1Api()
     max_namespace_inactive_days = os.environ['MAX_NAMESPACE_INACTIVE_HOURS']
 
     ns_whitelist = os.environ['NS_WHITELIST'].split(',')
@@ -47,8 +46,6 @@ def clean():
                 print("Cleaning up namespace %s" % namespace.metadata.name)
                 try:
                     v1api.delete_namespace(namespace.metadata.name, client.V1DeleteOptions())
-                    rbacApi.delete_collection_cluster_role(label_selector='namespace='+namespace.metadata.name)
-                    rbacApi.delete_collection_cluster_role_binding(label_selector='namespace='+namespace.metadata.name)
                     cleaned += 1
                 except Exception as ex:
                     print("Failed to cleanup %s" % namespace.metadata.name)


### PR DESCRIPTION
This reverts commit cb475e3a8c9df03c3664e86c0a3cdf3985f301e5.

No longer needed. It was introduced because of AEther creating new ClusterRole/ClusterRoleBinding for every transient namespace, but it's no longer the case now. So we don't need to these cleaning logic anymore. 